### PR TITLE
Make email optional

### DIFF
--- a/lib/ueberauth/strategy/patreon.ex
+++ b/lib/ueberauth/strategy/patreon.ex
@@ -149,14 +149,13 @@ defmodule Ueberauth.Strategy.Patreon do
           "last_name" => last_name,
           "about" => about,
           "image_url" => image_url,
-          "url" => url,
-          "email" => email
-        }
+          "url" => url
+        } = data
       }
     } = conn.private.patreon_user
 
     %Info{
-      email: email,
+      email: data["email"],
       name: full_name,
       first_name: first_name,
       last_name: last_name,


### PR DESCRIPTION
I don't receive an email for all users so this fails when some users want to connect their patreon